### PR TITLE
Extend Search Functionality to Include Storefront Metafields in Shopify

### DIFF
--- a/frontend/Chat.jsx
+++ b/frontend/Chat.jsx
@@ -29,7 +29,9 @@ export const Chat = () => {
             body: JSON.stringify({ message: userMessage }),
           });
 
-          const decodedStreamReader = stream.pipeThrough(new TextDecoderStream()).getReader();
+          const decodedStreamReader = stream
+            .pipeThrough(new TextDecoderStream())
+            .getReader();
 
           // handle any stream errors
           decodedStreamReader.closed.catch((error) => {
@@ -39,7 +41,8 @@ export const Chat = () => {
           let replyText = "";
           let done = false;
           while (!done) {
-            const { value, done: doneReading } = await decodedStreamReader.read();
+            const { value, done: doneReading } =
+              await decodedStreamReader.read();
 
             done = doneReading;
 
@@ -78,10 +81,23 @@ export const Chat = () => {
           <div>
             {productRecommendations?.products ? (
               productRecommendations.products.map((product, i) => (
-                <a key={`${i}_${product.title}`} href={"https://" + product.shop.domain + "/products/" + product.handle} target="_blank">
+                <a
+                  key={`${i}_${product.title}`}
+                  href={
+                    "https://" +
+                    product.shop.domain +
+                    "/products/" +
+                    product.handle
+                  }
+                  target="_blank"
+                >
                   {product.title}
                   {product.images.edges[0] && (
-                    <img style={{ border: "1px black solid" }} width="200px" src={product.images.edges[0].node.source} />
+                    <img
+                      style={{ border: "1px black solid" }}
+                      width="200px"
+                      src={product.images.edges[0].node.source}
+                    />
                   )}
                 </a>
               ))

--- a/routes/POST-chat.js
+++ b/routes/POST-chat.js
@@ -12,7 +12,9 @@ const parser = StructuredOutputParser.fromZodSchema(
   z.object({
     answer: z
       .string()
-      .describe("answer to the user's question, not including any product IDs, and only using product titles and descriptions"),
+      .describe(
+        "answer to the user's question, not including any product IDs, and only using product titles and descriptions"
+      ),
     productIds: z
       .array(z.string())
       .describe(
@@ -30,14 +32,19 @@ const prompt = new PromptTemplate({
   partialVariables: { format_instructions: parser.getFormatInstructions() },
 });
 
-
 /**
  * Route handler for POST chat
  *
  * @param { RouteContext } route context - see: https://docs.gadget.dev/guides/http-routes/route-configuration#route-context
  *
  */
-export default async function route({ request, reply, api, logger, connections }) {
+export default async function route({
+  request,
+  reply,
+  api,
+  logger,
+  connections,
+}) {
   const model = new OpenAI({
     temperature: 0,
     openAIApiKey: connections.openai.configuration.apiKey,
@@ -50,7 +57,10 @@ export default async function route({ request, reply, api, logger, connections }
   const chain = new LLMChain({ llm: model, prompt, outputParser: parser });
 
   // embed the incoming message from the user
-  const response = await connections.openai.embeddings.create({ input: request.body.message, model: "text-embedding-ada-002" });
+  const response = await connections.openai.embeddings.create({
+    input: request.body.message,
+    model: "text-embedding-ada-002",
+  });
 
   // find similar product descriptions
   const products = await api.shopifyProduct.findMany({
@@ -63,15 +73,23 @@ export default async function route({ request, reply, api, logger, connections }
   });
 
   // capture products in Gadget's Logs
-  logger.info({ products, message: request.body.message }, "found products most similar to user input");
+  logger.info(
+    { products, message: request.body.message },
+    "found products most similar to user input"
+  );
 
-  // JSON-stringify the structured product data to pass to the LLM
+  // Filter products with an 'active' status and then JSON-stringify
+  // the structured product data to pass to the LLM
   const productString = products
+    .filter((product) => product.status === "active")
     .map((product) =>
       JSON.stringify({
         id: product.id,
         title: product.title,
         description: product.body,
+        noofdaysdelivery: product.noofdaysdelivery,
+        sport: product.sport,
+        status: product.status,
       })
     )
     .join("\n");
@@ -79,7 +97,7 @@ export default async function route({ request, reply, api, logger, connections }
   // set up a new stream for returning the response from OpenAI
   // any data added to the stream will be streamed from Gadget to the route caller
   // in this case, the route caller is the frontend
-  const stream = new Readable({ read() { } });
+  const stream = new Readable({ read() {} });
 
   try {
     // start to return the stream immediately
@@ -87,19 +105,25 @@ export default async function route({ request, reply, api, logger, connections }
 
     let tokenText = "";
     // invoke the chain and add the streamed response tokens to the Readable stream
-    const resp = await chain.call({ question: request.body.message, products: productString }, [
-      new ConsoleCallbackHandler(),
-      {
-        // as the response is streamed in from OpenAI, stream it to the Gadget frontend
-        handleLLMNewToken: (token) => {
-          tokenText += token;
-          // parse out some of the response formatting tokens
-          if (tokenText.includes('"answer": "') && !tokenText.includes('",\n')) {
-            stream.push(token);
-          }
+    const resp = await chain.call(
+      { question: request.body.message, products: productString },
+      [
+        new ConsoleCallbackHandler(),
+        {
+          // as the response is streamed in from OpenAI, stream it to the Gadget frontend
+          handleLLMNewToken: (token) => {
+            tokenText += token;
+            // parse out some of the response formatting tokens
+            if (
+              tokenText.includes('"answer": "') &&
+              !tokenText.includes('",\n')
+            ) {
+              stream.push(token);
+            }
+          },
         },
-      },
-    ]);
+      ]
+    );
 
     // grab the complete response to store records in Chat Log model
     const { answer, productIds } = resp.text;
@@ -145,7 +169,10 @@ export default async function route({ request, reply, api, logger, connections }
       }
     }
 
-    logger.info({ answer, selectedProducts }, "answer and products being sent to the frontend for display");
+    logger.info(
+      { answer, selectedProducts },
+      "answer and products being sent to the frontend for display"
+    );
 
     // send the selected product to the stream
     stream.push(JSON.stringify({ products: selectedProducts }));
@@ -172,4 +199,4 @@ route.options = {
       required: ["message"],
     },
   },
-}
+};

--- a/shopifyProduct/utils.js
+++ b/shopifyProduct/utils.js
@@ -1,16 +1,33 @@
-export const createProductEmbedding = async ({ record, api, logger, connections }) => {
-  // only run if the product does not have an embedding, or if the title or body have changed
-  if (!record.descriptionEmbedding || record.changed("title") || record.changed("body")) {
+export const createProductEmbedding = async ({
+  record,
+  api,
+  logger,
+  connections,
+}) => {
+  console.log("here is the record from utils", record);
+  // only run if the product does not have an embedding, or if the title or body or noofdaysdelivery(metafield) or sport(metafield) have changed
+  if (
+    !record.descriptionEmbedding ||
+    record.changed("title") ||
+    record.changed("body") ||
+    record.changed("noofdaysdelivery") ||
+    record.changed("sport")
+  ) {
     try {
-      // get an embedding for the product title + description using the OpenAI connection
-      const response = await connections.openai.embeddings.create({ input: `${record.title}: ${record.body}`, model: "text-embedding-ada-002" });
+      // get an embedding for the product title + description + no of delivery days + sport using the OpenAI connection
+      const response = await connections.openai.embeddings.create({
+        input: `${record.title}: Estimated delivery in ${record.noofdaysdelivery} days - It is used for ${record.sport} sport - ${record.body}`,
+        model: "text-embedding-ada-002",
+      });
       const embedding = response.data[0].embedding;
 
       // write to the Gadget Logs
       logger.info({ id: record.id }, "got product embedding");
 
       // use the internal API to store vector embedding in Gadget database, on shopifyProduct model
-      await api.internal.shopifyProduct.update(record.id, { shopifyProduct: { descriptionEmbedding: embedding } });
+      await api.internal.shopifyProduct.update(record.id, {
+        shopifyProduct: { descriptionEmbedding: embedding },
+      });
     } catch (error) {
       logger.error({ error }, "error creating embedding");
     }


### PR DESCRIPTION
  ### Summary
  - Created embedding for the _noofdaysdelivery_ and _sport_ metafields along with the product title and description.
  - Filtered the products with an active status.
  - With the addition of metafields in the embedding text it increases the higher chance of suggesting the expected results.
  
 ### Note for reviewer for testing the changes locally
 - Create some products with the metafields _noofdaysdelivery_ and _sport_.
 - Sync the metafields with the models in the App.
 - If the App is broken, the changes could be reviewed from the log files of the Gadget App.
 
 
 ## Attachments
|Some Common Questions|
|-|
|![Q1](https://github.com/dear-digital/search/assets/52121241/1528d377-538a-487b-a521-906eb3db3f43)|
|![Q3](https://github.com/dear-digital/search/assets/52121241/6469fac4-3a1c-4e41-b7bc-b19f2bbaba67)|
|![Q4](https://github.com/dear-digital/search/assets/52121241/ae91362a-319f-4905-8614-e048f2fd7888)|
|![Q2](https://github.com/dear-digital/search/assets/52121241/ce529b1a-822e-4859-a58e-8ee6c55b2509)|

 

